### PR TITLE
Add auto-apply functionality for GNOME folder organization

### DIFF
--- a/gnome-dash-fix-reload.sh
+++ b/gnome-dash-fix-reload.sh
@@ -34,6 +34,21 @@ folders=(
     "universal-access"
 )
 
+# Categories mapping for auto-apply functionality
+declare -A categories
+categories=(
+    ["accessories"]="Utility"
+    ["games"]="Game"
+    ["graphics"]="Graphics"
+    ["internet"]="Network"
+    ["office"]="Office"
+    ["development"]="Development"
+    ["science"]="Science"
+    ["sound---video"]="AudioVideo"
+    ["system-tools"]="System"
+    ["universal-access"]="Accessibility"
+)
+
 #================================#
 # Functions
 #================================#
@@ -42,6 +57,7 @@ function HELP()
     echo "Usage:"
     echo " -a, apply  - Organizing applications to folders"
     echo " -r, revert - Revert to default"
+    echo " -aa, auto-apply - Auto-apply with enhanced folder configuration"
     exit 0
 }
 
@@ -54,6 +70,28 @@ function APPLY_FOLDERS()
     gsettings set $default_folders folder-children "[$folders_string]"
 }
 
+function AUTO_APPLY_FOLDERS()
+{
+    # Create and configure each folder
+    for folder in "${folders[@]}"; do
+        # Capitalize folder name for display
+        display_name="$(tr '[:lower:]' '[:upper:]' <<< ${folder:0:1})${folder:1}"
+        category=${categories[$folder]}
+
+        # Set folder name
+        gsettings set $default_folders.folder:/org/gnome/desktop/app-folders/folders/$folder/ name "$display_name"
+        # Assign category to folder
+        gsettings set $default_folders.folder:/org/gnome/desktop/app-folders/folders/$folder/ categories "['$category']"
+    done
+
+    # Apply all folders
+    folders_string=$(printf "'%s', " "${folders[@]}" | sed 's/, $//')
+    gsettings set $default_folders folder-children "[$folders_string]"
+
+    echo "Auto-apply completed successfully!"
+    echo "Folders configured with proper names and categories."
+}
+
 function REVERT_FOLDERS()
 {
     # Revert
@@ -63,5 +101,6 @@ function REVERT_FOLDERS()
 case $1 in
     -a|apply) APPLY_FOLDERS     ;;
     -r|revert) REVERT_FOLDERS ;;
+    -aa|auto-apply) AUTO_APPLY_FOLDERS ;;
     *) HELP ;;
 esac


### PR DESCRIPTION
### What does this PR do?

This PR adds an "auto-apply" feature to the GNOME folder organization script. 

### Changes:

- Adds a mapping of GNOME app categories to folder names.
- Introduces the `-aa | auto-apply` option to automatically create folders with:
  - Proper display names (capitalized)
  - Assigned categories based on FreeDesktop standards
- Maintains original `apply` and `revert` functionality for backward compatibility.

### Benefits:

- Users no longer need to manually configure categories for GNOME Shell folders.
- Provides a fully automated way to organize applications on the GNOME dashboard.
- Improves usability and consistency with FreeDesktop standards.

### How to use:

```bash
./script.sh -aa   # Auto-applies folder configuration
./script.sh -a    # Standard apply
./script.sh -r    # Revert to default